### PR TITLE
stash and restore the database for acceptance tests

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 npm-debug.log
+
+tests/dump/

--- a/app/.scripts/run-tests.sh
+++ b/app/.scripts/run-tests.sh
@@ -1,22 +1,51 @@
 #!/bin/bash
 
-port=13010
+# Note: requires a running meteor instance
+
+
 watch=""
-SECONDS=0
 quit=0
+
 
 if [ "$WATCH" == "true" ]; then
   watch="--watch";
+  SECONDS=0
 fi
 
-MONGO_URL=mongodb://localhost:13001/${port} meteor --settings settings.json --port ${port}
-CUCUMBER_TAIL=1 chimp $watch --ddp=http://localhost:13010 \
-                  --watch \
-                  --path=tests/ \
-                  --coffee=true \
-                  --compiler=coffee:coffee-script/register \
-                  --chai=true \
-                  --sync=false
-kill `lsof -t -i:${port}`
 
-echo "$(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds elapsed"
+# Put the data back
+function finish {
+  echo "Restoring the stashed data..."
+  mongorestore -h 127.0.0.1 --port 13001 -d meteor tests/dump/meteor
+  rm -rf tests/dump/
+}
+trap finish EXIT
+trap finish INT
+trap finish SIGINT  # 2
+trap finish SIGQUIT # 3
+trap finish SIGKILL # 9
+trap finish SIGTERM # 15
+# Note: must be bound before starting the actual test
+
+
+# Back up the current database
+rm -rf tests/dump/
+echo "Create a bson dump of our 'meteor' db..."
+mongodump -h 127.0.0.1 --port 13001 -d meteor -o tests/dump/
+
+
+# Run our tests
+chimp $watch --ddp=http://localhost:13000 \
+        --path=tests/ \
+        --coffee=true \
+        --compiler=coffee:coffee-script/register \
+        --chai=true \
+        --sync=false
+
+
+# Output time elapsed
+if [ "$WATCH" != "true" ]; then
+  echo ''
+  echo "$(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds elapsed"
+  echo ''
+fi

--- a/app/Makefile
+++ b/app/Makefile
@@ -5,3 +5,7 @@ run:
 # Acceptance test
 test:
 	npm run test
+
+# Acceptance test (watch)
+test-watch:
+	npm run test-watch

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "start": "meteor -p 13000 --settings settings.json",
     "pretest": "npm install --only=dev",
-    "test": ".scripts/run-tests.sh"
+    "test": ".scripts/run-tests.sh",
+    "test-watch": "WATCH=true .scripts/run-tests.sh"
   },
   "dependencies": {
     "autoprefixer": "^6.3.1",

--- a/app/tests/step_definitions/common_steps.coffee
+++ b/app/tests/step_definitions/common_steps.coffee
@@ -15,6 +15,10 @@ do ->
           # Meteor.logout()
         ), callback
 
+    # Clean-up for production
+    @After (callback) ->
+      @server.call 'resetFixture'
+
     @When /^I click "([^"]*)"$/, (selector) ->
       @client
         .waitForVisible(selector)


### PR DESCRIPTION
So resetting the database is easy (xolvio:cleaner package).

This PR adds the support for stashing the database and restoring it upon completion (or ^C/^D signals).
This way we do not need to start any additional meteor instances and the data remains safe once the testing is over.