### PR TITLE
Do not redirect user if logged in on startup

### DIFF
--- a/app/packages/openam/routes.coffee
+++ b/app/packages/openam/routes.coffee
@@ -1,7 +1,11 @@
 Meteor.startup ->
   Meteor.autorun ->
     if Meteor.userId()
-      FlowRouter.go '/admin/surveys'
+      curentPath = FlowRouter.current().path
+      if curentPath == '/login'
+        FlowRouter.go '/admin/surveys'
+      else
+        FlowRouter.go curentPath
     else
       FlowRouter.go 'login'
 


### PR DESCRIPTION
Fixes a bug in the openam router which redirected the user to `admin/surveys` on startup/refresh.