### PR TITLE
Remove question property in new form

### DIFF
--- a/app/client/survey_admin/survey_admin_forms_edit.coffee
+++ b/app/client/survey_admin/survey_admin_forms_edit.coffee
@@ -289,13 +289,13 @@ Template.survey_admin_forms_edit.events
     if formId
       Meteor.call 'editForm', formId, props, (error)->
         if error
-          toastr.error 'Error', error.message
+          toastr.error error.message
         else
           FlowRouter.go "/admin/surveys/#{instance.survey.id}/forms"
     else
       Meteor.call 'createForm', instance.survey.id, props, (error, formId)->
         if error
-          toastr.error 'Error'
+          toastr.error error.message
         else
           FlowRouter.go "/admin/surveys/#{instance.survey.id}/forms/#{formId}"
 

--- a/app/server/methods.coffee
+++ b/app/server/methods.coffee
@@ -1,8 +1,8 @@
 Parse = require 'parse/node'
 {Survey, Form, Question} = require '../imports/models'
 
-handleError = (parse, error) ->
-  throw new Meteor.Error parse, error.message
+handleError = (error) ->
+  throw new Meteor.Error error.code, error.message
 
 geo = new GeoCoder(
   geocoderProvider: "google",
@@ -18,10 +18,9 @@ Meteor.methods
       throw new Meteor.Error(501, 'The title field cannot be empty')
     fields.createdBy = @userId
     survey = new Survey()
-    survey.save(fields).then ((survey) ->
+    survey.save(fields).then (survey) ->
       survey.id
-    ), (error) ->
-      throw new Meteor.Error error
+    , handleError
 
   createForm: (surveyId, props) ->
     @unblock()
@@ -55,13 +54,7 @@ Meteor.methods
           relation.add form
           survey.save()
           form.id
-        , (form, error) ->
-          handleError 'parse', error
-      , (form, error) ->
-        handleError 'parse', error
-    , (form, error) ->
-      handleError 'parse', error
-
+        , handleError
 
   geocode: (address) ->
     geo.geocode(address)
@@ -74,9 +67,9 @@ Meteor.methods
 
     query = new Parse.Query Form
     query.get(formId).then (form) ->
-      form.save props, ->
-        error: (form, error) ->
-          handleError 'parse', error
+      form.save(props).then (form) ->
+        form
+      , handleError
 
   updateForm: (formId, form) ->
     @unblock()


### PR DESCRIPTION
PT Bug: https://www.pivotaltracker.com/story/show/118965765
Cause of the error: Early on I set the `questions` property of new forms to an empty array. It is a relation on the server so there was a conflict with the schema on save.

I also fixed some of the error handling.