### PR TITLE
Fix bugs with sorting lists

### DIFF
--- a/app/client/questions/questions.coffee
+++ b/app/client/questions/questions.coffee
@@ -17,7 +17,7 @@ Template.questions.onRendered ->
   Meteor.autorun ->
     if instance.fetched.get() and instance.questions?.findOne()
       Meteor.defer ->
-        Sort.create questions,
+        Sort.create questionList,
           handle: '.sortable-handle'
           onSort: (event) ->
             updateSortOrder event, instance.form, 'questions'

--- a/app/client/questions/questions.jade
+++ b/app/client/questions/questions.jade
@@ -5,7 +5,7 @@ template(name="questions")
 
     if fetched
       if hasQuestions
-        ul.list-group#questions
+        ul.list-group#questionList
           each questions
             li.list-group-item.question-link(data-id=parseId)
               span.sortable-handle

--- a/app/client/survey_admin/survey_admin_forms.coffee
+++ b/app/client/survey_admin/survey_admin_forms.coffee
@@ -13,12 +13,12 @@ Template.survey_admin_forms.onCreated ->
 Template.survey_admin_forms.onRendered ->
   instance = @
   Meteor.autorun ->
-    Meteor.defer ->
-      if instance.fetched.get() and instance.forms?.findOne()
-        Sort.create document.getElementById 'forms',
+    if instance.fetched.get() and instance.forms?.findOne()
+      Meteor.defer ->
+        Sort.create formList,
           handle: '.sortable-handle'
           onSort: (event) ->
-            updateSortOrder(event, instance.survey, 'forms')
+            updateSortOrder event, instance.survey, 'forms'
 
 Template.survey_admin_forms.helpers
   forms: ->

--- a/app/client/survey_admin/survey_admin_forms.jade
+++ b/app/client/survey_admin/survey_admin_forms.jade
@@ -7,7 +7,7 @@ template(name="survey_admin_forms")
 
     if fetched
       if hasForms
-        ul.list-group#forms
+        ul.list-group#formList
           each forms
             li.list-group-item.form-link(data-id=parseId)
               span.sortable-handle

--- a/app/imports/helpers.coffee
+++ b/app/imports/helpers.coffee
@@ -22,6 +22,7 @@ exports.updateSortOrder = (event, parentObj, relatedObjString) ->
     query.ascending 'order'
     if movingUp
       query.greaterThanOrEqualTo 'order', newOrder
+      query.lessThanOrEqualTo 'order', oldOrder
     else
       query.lessThanOrEqualTo 'order', newOrder
       query.greaterThan 'order', oldOrder


### PR DESCRIPTION
While fixing the bug with sorting the Form list (https://www.pivotaltracker.com/story/show/119087711) I found another where if the list item was moved up the list, the order of all objects below the moved object where increased. Now it only updates the objects below the new position and and above the old position.