### PR TITLE
Update form triggers

### DIFF
--- a/app/client/delete_survey_modal/delete_survey_modal.coffee
+++ b/app/client/delete_survey_modal/delete_survey_modal.coffee
@@ -1,3 +1,5 @@
+{Survey} = require '../../imports/models'
+
 Template.delete_survey_modal.onCreated ->
   @deleting = new ReactiveVar false
 
@@ -14,9 +16,11 @@ Template.delete_survey_modal.events
     event.preventDefault()
     instance.data.surveys.remove parseId: instance.surveyId
     query = new Parse.Query Survey
-    query.get(instance.surveyId).then (survey) ->
-      survey.destroy().then (obj) ->
+    query.get(instance.surveyId)
+      .then (survey) ->
+        survey.destroy()
+      .then (obj) ->
         $('#delete-survey-modal').modal('hide')
         instance.deleting.set false
-    , (error) ->
-      toastr.error error.message
+      .fail (error) ->
+        toastr.error error.message

--- a/app/client/survey_admin/survey_admin_forms_edit.coffee
+++ b/app/client/survey_admin/survey_admin_forms_edit.coffee
@@ -283,15 +283,17 @@ Template.survey_admin_forms_edit.events
         return
       trigger =
         type: type
-        radius: getRadius()
-        loc: getCoordinates()
+        properties:
+          radius: getRadius()
+          loc: getCoordinates()
     if type == 'datetime'
       if not getDatetime()
         toastr.error 'Please select a date and time.'
         return
       trigger =
         type: type
-        datetime: getDatetime()
+        properties:
+          datetime: getDatetime()
     props =
       title: form.name.value
       trigger: trigger
@@ -365,10 +367,11 @@ Template.survey_admin_forms_edit.onRendered ->
         if @form and @trigger
           type = @trigger.get 'type'
           @triggerType.set type
+          triggerProps = @trigger.get 'properties'
           if type == 'datetime'
-            _datetimeTrigger.data('DateTimePicker').date new Date @trigger.get 'datetime'
+            _datetimeTrigger.data('DateTimePicker').date new Date triggerProps.datetime
           else
-            coordinates = @trigger.get('loc').coordinates
+            coordinates = triggerProps.loc.coordinates
             latLng = L.latLng coordinates[1], coordinates[0]
             addMarker latLng, true
             resizeMap()

--- a/app/client/survey_admin/survey_admin_forms_edit.coffee
+++ b/app/client/survey_admin/survey_admin_forms_edit.coffee
@@ -111,9 +111,8 @@ radiusToZoomLevel = () ->
 # @return [Array] the user defined coordinates as geoJSON Point or null
 getCoordinates = () ->
   latLng = _geofenceMarker.getLatLng()
-
-  type: 'Point'
-  coordinates: [latLng.lng, latLng.lat]
+  latitude: latLng.lat
+  longitude: latLng.lng
 
 # set the UI to the L.latLng object
 #
@@ -285,7 +284,7 @@ Template.survey_admin_forms_edit.events
         type: type
         properties:
           radius: getRadius()
-          loc: getCoordinates()
+        location: getCoordinates()
     if type == 'datetime'
       if not getDatetime()
         toastr.error 'Please select a date and time.'

--- a/app/client/survey_admin/survey_admin_forms_edit.coffee
+++ b/app/client/survey_admin/survey_admin_forms_edit.coffee
@@ -370,7 +370,7 @@ Template.survey_admin_forms_edit.onRendered ->
           if type == 'datetime'
             _datetimeTrigger.data('DateTimePicker').date new Date triggerProps.datetime
           else
-            coordinates = triggerProps.loc.coordinates
-            latLng = L.latLng coordinates[1], coordinates[0]
+            location = @trigger.get 'location'
+            latLng = L.latLng location.latitude, location.longitude
             addMarker latLng, true
             resizeMap()

--- a/app/client/survey_admin/survey_admin_forms_edit.jade
+++ b/app/client/survey_admin/survey_admin_forms_edit.jade
@@ -44,12 +44,12 @@ template(name="survey_admin_forms_edit")
                       min='0'
                       step='.1'
                       name='radiusTrigger'
-                      value='#{trigger.attributes.radius}'
+                      value='#{trigger.attributes.properties.radius}'
                       placeholder='Enter radius in miles')
                     input#coordinateBox.form-control.input-sm.inline-70(
                       type='string'
                       name='coordinateBox',
-                      value='#{trigger.attributes.coordinates}'
+                      value='#{trigger.attributes.properties.coordinates}'
                       placeholder='GPS Coordinates'
                       readonly)
                 .map-floating-row

--- a/app/imports/models.coffee
+++ b/app/imports/models.coffee
@@ -72,6 +72,16 @@ Form = Parse.Object.extend 'Form',
       survey.save().then ->
         form
 
+  update: (props) ->
+    form = @
+    # Stash the trigger properties and remove from props
+    # so they aren't saved to form
+    triggerProps = props.trigger
+    delete props.trigger
+    @save(props).then ->
+      form.updateTrigger(triggerProps).then ->
+        form
+
   addTrigger: (props) ->
     trigger = new Trigger()
     form = @
@@ -83,6 +93,16 @@ Form = Parse.Object.extend 'Form',
     query.first().then (trigger) ->
       trigger
 
+  updateTrigger: (props) ->
+    @getTrigger().then (trigger) ->
+      # Transform date and set old type data to null
+      if props.type == 'datetime'
+        props.datetime = new Date props.datetime
+        props.loc = null
+      else
+        props.datetime = null
+      trigger.update props
+
 Trigger = Parse.Object.extend 'Trigger',
   create: (props, form) ->
     if props.type == 'datetime'
@@ -92,6 +112,11 @@ Trigger = Parse.Object.extend 'Trigger',
       relation.add trigger
       form.save().then ->
         trigger.id
+
+  update: (props) ->
+    if props.type == 'datetime'
+      props.datetime = new Date(props.datetime)
+    @save(props)
 
 Question = Parse.Object.extend 'Question'
 

--- a/app/imports/models.coffee
+++ b/app/imports/models.coffee
@@ -97,16 +97,13 @@ Form = Parse.Object.extend 'Form',
     @getTrigger().then (trigger) ->
       # Transform date and set old type data to null
       if props.type == 'datetime'
-        props.datetime = new Date props.datetime
-        props.loc = null
-      else
-        props.datetime = null
+        props.properties.datetime = new Date props.properties.datetime
       trigger.update props
 
 Trigger = Parse.Object.extend 'Trigger',
   create: (props, form) ->
     if props.type == 'datetime'
-      props.datetime = new Date props.datetime
+      props.properties.datetime = new Date props.properties.datetime
     @save(props).then (trigger) ->
       relation = form.relation 'triggers'
       relation.add trigger
@@ -115,7 +112,7 @@ Trigger = Parse.Object.extend 'Trigger',
 
   update: (props) ->
     if props.type == 'datetime'
-      props.datetime = new Date(props.datetime)
+      props.properties.datetime = new Date(props.properties.datetime)
     @save(props)
 
 Question = Parse.Object.extend 'Question'

--- a/app/lib/models.coffee
+++ b/app/lib/models.coffee
@@ -1,1 +1,0 @@
-@Survey = Parse.Object.extend 'Survey'

--- a/app/server/methods.coffee
+++ b/app/server/methods.coffee
@@ -35,14 +35,9 @@ Meteor.methods
     geo.geocode(address)
 
   editForm: (formId, props) ->
-    trigger = props.trigger
-    if trigger
-      if trigger.type == 'datetime'
-        trigger.datetime = new Date(trigger.datetime)
-
     query = new Parse.Query Form
     query.get(formId).then (form) ->
-      form.save(props).then (form) ->
+      form.update(props).then (form) ->
         form
       , handleError
     , handleError

--- a/app/server/methods.coffee
+++ b/app/server/methods.coffee
@@ -29,6 +29,7 @@ Meteor.methods
     query.get(surveyId).then (survey) ->
       survey.addForm(props).then (formId) ->
         formId
+      , handleError
     , handleError
 
   geocode: (address) ->


### PR DESCRIPTION
Updates a Form's trigger parse object when form is updated.
Adds a few methods: 
`Form` model: `update` and `updateTrigger` 
`Trigger` model: `update` (which is, I suppose, necessary due to changing the datetime rather than just saving the trigger)
PT Bug: https://www.pivotaltracker.com/story/show/119078683