### PR TITLE
Move Parse object manipulation to client side

### DIFF
--- a/app/client/create_survey_modal/create_survey_modal.coffee
+++ b/app/client/create_survey_modal/create_survey_modal.coffee
@@ -14,7 +14,7 @@ Template.create_survey_modal.events
     surveyProps = _.object $(event.target).serializeArray().map(
       ({name, value})-> [name, value]
     )
-    surveyProps.createdBy = Meteor.userId()
+    surveyProps.createdBy = Parse.User.current()
     survey = new Survey()
     survey.save(surveyProps)
       .then (survey)->

--- a/app/client/create_survey_modal/create_survey_modal.coffee
+++ b/app/client/create_survey_modal/create_survey_modal.coffee
@@ -1,3 +1,5 @@
+{Survey} = require '../../imports/models'
+
 Template.create_survey_modal.onCreated ->
   @creating = new ReactiveVar false
 
@@ -9,22 +11,20 @@ Template.create_survey_modal.events
   'submit form': (event, instance) ->
     event.preventDefault()
     instance.creating.set true
-    form = _.object $(event.target).serializeArray().map(
+    surveyProps = _.object $(event.target).serializeArray().map(
       ({name, value})-> [name, value]
     )
-
-    Meteor.call 'createSurvey', form, (error, surveyId) ->
-      instance.creating.set false
-      if error
-        if _.isObject error.reason
-          for key, value of error.reason
-            toastr.error('Error: ' + value)
-        else
-          toastr.error('Unknown Error')
-      else
+    surveyProps.createdBy = Meteor.userId()
+    survey = new Survey()
+    survey.save(surveyProps)
+      .then (survey)->
         $(event.target).closest('.modal').modal('hide')
         window.setTimeout(->
           # Wait for modal to hide so the backdrop won't get stuck open.
           toastr.success('Success')
-          FlowRouter.go '/admin/surveys/' + surveyId
+          FlowRouter.go '/admin/surveys/' + survey.id
         , 300)
+      .fail (error)->
+        toastr.error(error.message)
+      .always ->
+        instance.creating.set false

--- a/app/client/questions/add_question.coffee
+++ b/app/client/questions/add_question.coffee
@@ -116,27 +116,19 @@ Template.add_question.events
     parseForm = null
     query = new Parse.Query Form
     query.get(instance.form.id)
-      .then (_parseForm) ->
-        parseForm = _parseForm
-        parseForm.getLastQuestionOrder()
-      .then (lastQuestionOrder) ->
-        question.order = ++lastQuestionOrder or 1
-        parseQuestion = new Question()
-        parseQuestion.save(question)
-      .then (parseQuestion) ->
-        question.parseId = parseQuestion.id
-        relation = parseForm.relation 'questions'
-        relation.add parseQuestion
-        parseForm.save()
-      .then (parseForm)->
+      .then (form) ->
+        form.addQuestion(question)
+      .then (question) ->
         form.reset()
         instance.choices.find().forEach ({_id})->
           instance.choices.remove _id
         lastItemOrder = instance.questions.findOne({}, sort: {order: -1})?.order
-        question.order = ++lastItemOrder or 1
-        instance.questions.insert question
+        instance.questions.insert
+          parseId: question.id
+          order: ++lastItemOrder or 1
+          text: question.get 'text'
         toastr.success 'Question added'
-      .fail (error)->
+      .fail (error) ->
         toastr.error error.message
 
   'click .add-choice': (event, instance)->

--- a/app/client/questions/add_question.coffee
+++ b/app/client/questions/add_question.coffee
@@ -113,11 +113,8 @@ Template.add_question.events
       type: instance.type.get()
       properties: questionProperties
       required: questionProperties.required is 'on'
-    parseForm = null
-    query = new Parse.Query Form
-    query.get(instance.form.id)
-      .then (form) ->
-        form.addQuestion(question)
+
+    instance.form.addQuestion(question)
       .then (question) ->
         form.reset()
         instance.choices.find().forEach ({_id})->

--- a/app/client/questions/questions.coffee
+++ b/app/client/questions/questions.coffee
@@ -1,4 +1,3 @@
-Parse = require 'parse'
 Sort = require 'sortablejs'
 {updateSortOrder} = require '../../imports/helpers'
 {Question} = require '../../imports/models'

--- a/app/client/survey_admin/survey_admin.coffee
+++ b/app/client/survey_admin/survey_admin.coffee
@@ -5,11 +5,12 @@ Template.survey_admin.onCreated ->
   surveyId = @data.id
   instance = @
   query = new Parse.Query Survey
-  query.get(surveyId).then (survey) ->
-    instance.fetched.set true
-    instance.survey = survey
-  , (obj, error) ->
-    throw new Meteor.Error 'server', error.message
+  query.get(surveyId)
+    .then (survey) ->
+      instance.fetched.set true
+      instance.survey = survey
+    .fail (error) ->
+      toastr error.message
 
 Template.survey_admin.helpers
   survey: ->

--- a/app/client/survey_admin/survey_admin_form_details.coffee
+++ b/app/client/survey_admin/survey_admin_form_details.coffee
@@ -3,11 +3,12 @@ Template.survey_admin_form_details.onCreated ->
   @questionCollection = new Meteor.Collection null
   survey = @data.survey
   instance = @
-  survey.getForm(@data.formId).then (form) ->
-    instance.form = form
-    instance.fetched.set true
-  , (form, error) ->
-    toastr.error error.message
+  survey.getForm(@data.formId)
+    .then (form) ->
+      instance.form = form
+      instance.fetched.set true
+    .fail (error) ->
+      toastr.error error.message
 
 Template.survey_admin_form_details.helpers
   form: ->

--- a/app/client/survey_admin/survey_admin_forms_edit.coffee
+++ b/app/client/survey_admin/survey_admin_forms_edit.coffee
@@ -273,7 +273,6 @@ Template.survey_admin_forms_edit.events
 
   'submit form': (event, instance)->
     event.preventDefault()
-    formId = instance.form?.id
     form = event.currentTarget
     trigger = null
     # what trigger is active
@@ -298,24 +297,18 @@ Template.survey_admin_forms_edit.events
       title: form.name.value
       trigger: trigger
 
-    if formId
-      query = new Parse.Query Form
-      query.get(formId)
-        .then (form) ->
-          form.save(props)
-        .then (form) ->
+    form = instance.form
+    if form
+      form.save(props)
+        .then ->
           FlowRouter.go "/admin/surveys/#{instance.survey.id}/forms"
         .fail (error) ->
           toastr.error error.message
     else
-      query = new Parse.Query Survey
-      query.get(instance.survey.id)
-        .then (survey) ->
-          survey.addForm(props)
-        .then (form)->
+      instance.survey.addForm(props)
+        .then (form) ->
           FlowRouter.go "/admin/surveys/#{instance.survey.id}/forms/#{form.id}"
-        .fail (error)->
-          console.log error
+        .fail (error) ->
           toastr.error error.message
 
 Template.survey_admin_forms_edit.onRendered ->

--- a/app/client/survey_admin/survey_admin_forms_edit.coffee
+++ b/app/client/survey_admin/survey_admin_forms_edit.coffee
@@ -292,14 +292,15 @@ Template.survey_admin_forms_edit.events
         return
       trigger =
         type: type
-        datetime: new Date getDatetime()
+        properties:
+          datetime: new Date getDatetime()
     props =
       title: form.name.value
       trigger: trigger
 
     form = instance.form
     if form
-      form.save(props)
+      form.update(props)
         .then ->
           FlowRouter.go "/admin/surveys/#{instance.survey.id}/forms"
         .fail (error) ->

--- a/app/imports/models.coffee
+++ b/app/imports/models.coffee
@@ -131,7 +131,11 @@ Trigger = Parse.Object.extend 'Trigger',
     form.save()
 
 
-Question = Parse.Object.extend 'Question'
+Question = Parse.Object.extend 'Question',
+  addToForm: (form) ->
+    relation = form.relation 'questions'
+    relation.add @
+    form.save()
 
 module.exports =
   Survey: Survey

--- a/app/imports/models.coffee
+++ b/app/imports/models.coffee
@@ -1,10 +1,10 @@
 {buildMeteorCollection} = require './helpers'
 
 Survey = Parse.Object.extend 'Survey',
-  validate: (props) ->
-    if not props?.title or props.title.length == 0
-      return new Parse.Error(Parse.VALIDATION_ERROR, 'The title field cannot be empty')
-    return false
+  # validate: (props) ->
+  #   if not props?.title or props.title.length == 0
+  #     return new Parse.Error(Parse.VALIDATION_ERROR, 'The title field cannot be empty')
+  #   return
 
   getForms: (returnMeteorCollection, collection) ->
     query = @relation('forms').query()
@@ -39,25 +39,25 @@ Survey = Parse.Object.extend 'Survey',
 
   addForm: (props) ->
     survey = @
-    parseForm = new Form()
-    window.F = parseForm
-    window.S = survey
+    form = new Form()
     @buildForm(props)
       .then (formProps) ->
-        parseForm.save(formProps)
-      .then ->
-        triggerProps = props.trigger
-        if triggerProps
-          parseForm.addTrigger(triggerProps)
-      .then ->
-        console.log parseForm
-        relation = survey.relation 'forms'
-        relation.add parseForm
-        survey.save()
-      .then ->
-        parseForm
+        form.create(formProps, survey)
+      .then (form) ->
+        form
 
 Form = Parse.Object.extend 'Form',
+  create: (props, survey) ->
+    form = @
+    @save(props)
+      .then ->
+        form.addTrigger(props.trigger, form)
+      .then ->
+        relation = survey.relation 'forms'
+        relation.add form
+        survey.save()
+      .then ->
+        form
 
   getQuestions: (returnMeteorCollection, collection) ->
     query = @relation('questions').query()

--- a/app/imports/models.coffee
+++ b/app/imports/models.coffee
@@ -116,6 +116,19 @@ Form = Parse.Object.extend 'Form',
       .then ->
         form
 
+  addQuestion: (props) ->
+    form = @
+    @getLastQuestionOrder()
+      .then (lastQuestionOrder) ->
+        props.order = ++lastQuestionOrder or 1
+        question = new Question()
+        question.save(props)
+          .then (question) ->
+            relation = form.relation 'questions'
+            relation.add question
+            form.save().then ->
+              question
+
   addTrigger: (props) ->
     trigger = new Trigger()
     trigger.create(props, @)

--- a/app/imports/models.coffee
+++ b/app/imports/models.coffee
@@ -1,10 +1,10 @@
 {buildMeteorCollection} = require './helpers'
 
 Survey = Parse.Object.extend 'Survey',
-  # validate: (props) ->
-  #   if not props?.title or props.title.length == 0
-  #     return new Parse.Error(Parse.VALIDATION_ERROR, 'The title field cannot be empty')
-  #   return
+  validate: (props) ->
+    if props?.title?.length == 0
+      return new Parse.Error(Parse.VALIDATION_ERROR, 'The title field cannot be empty')
+    Parse.Object.prototype.validate.call(this, props)
 
   getForms: (returnMeteorCollection, collection) ->
     query = @relation('forms').query()
@@ -51,7 +51,7 @@ Form = Parse.Object.extend 'Form',
     form = @
     @save(props)
       .then ->
-        form.addTrigger(props.trigger, form)
+        form.addTrigger(props.trigger)
       .then ->
         relation = survey.relation 'forms'
         relation.add form

--- a/app/imports/models.coffee
+++ b/app/imports/models.coffee
@@ -33,7 +33,7 @@ Survey = Parse.Object.extend 'Survey',
     @getLastFormOrder().then (lastFormOrder) ->
       order = ++lastFormOrder or 1
       title: props.title
-      createdBy: Parse.User.current()?
+      createdBy: Parse.User.current()
       order: order
       trigger: props.trigger
 
@@ -104,6 +104,7 @@ Form = Parse.Object.extend 'Form',
     @getLastQuestionOrder()
       .then (lastQuestionOrder) ->
         props.order = ++lastQuestionOrder or 1
+        props.createdBy = Parse.User.current()
         question = new Question()
         question.save(props)
       .then (question) ->

--- a/app/packages/openam/login.coffee
+++ b/app/packages/openam/login.coffee
@@ -7,10 +7,14 @@ Template.login.events
     passw = form.password.value.trim()
 
     Meteor.call 'loginUser', email, passw, (err, token) ->
-      Meteor.loginWithToken(token)
-      Parse.User.logIn(email, passw)
-        .then ()->
-          console.log(Parse.User.current())
-        .fail (error)->
-          toastr.error('Could not log into Parse.')
-          console.log(error)
+      Meteor.loginWithToken token, (err)->
+        if err
+          toastr.error('Could not log into Meteor')
+          return
+        Parse.User.logIn(email, passw)
+          .then ()->
+            console.log(Parse.User.current())
+          .fail (error)->
+            toastr.error('Could not log into Parse.')
+            console.log(error)
+            Meteor.logout()

--- a/app/packages/openam/login.coffee
+++ b/app/packages/openam/login.coffee
@@ -8,4 +8,9 @@ Template.login.events
 
     Meteor.call 'loginUser', email, passw, (err, token) ->
       Meteor.loginWithToken(token)
-      Parse.User.logIn email, passw
+      Parse.User.logIn(email, passw)
+        .then ()->
+          console.log(Parse.User.current())
+        .fail (error)->
+          toastr.error('Could not log into Parse.')
+          console.log(error)

--- a/app/packages/openam/signup.coffee
+++ b/app/packages/openam/signup.coffee
@@ -7,6 +7,42 @@ Template.signup.events
     passw = form.password.value.trim()
 
     Meteor.call("registerNewUser", email, passw, (err, res) ->
-      unless err
-        form.reset()
+      if err
+        toastr.error("OpenAM Error: " + err.message)
+        console.log err, res
+        return
+      # Create Meteor user
+      meteorId = Accounts.createUser(
+        email: email
+        password: passw
+      , (err)->
+        if err
+          toastr.error("Meteor Error: " + err.message)
+          return
+        console.log Parse.User.current()
+        # Create Parse User
+        parseUser = new Parse.User()
+        parseUserData =
+          username: email
+          password: passw
+          email   : email
+          meteorId: meteorId
+          role    : 'admin'
+        currentUserSessionToken = Parse.User.current().getSessionToken()
+        parseUser.signUp(parseUserData)
+          .then ->
+            Parse.User.become(currentUserSessionToken)
+          .then ->
+            query = new Parse.Query(Parse.Role)
+            query.equalTo("name", "admin")
+            query.first()
+          .then (adminRole)->
+            console.log Parse.User.current()
+            adminRole.relation("users").add(parseUser)
+            adminRole.save()
+          .then ->
+            form.reset()
+          .fail (err)->
+            toastr.error("Parse Error: " + err.message)
+      )
     )

--- a/app/server/methods.coffee
+++ b/app/server/methods.coffee
@@ -1,9 +1,3 @@
-{Survey, Form, Question} = require '../imports/models'
-
-handleError = (error) ->
-  console.log error
-  throw new Meteor.Error error.code, error.message
-
 geo = new GeoCoder(
   geocoderProvider: "google",
   httpAdapter: "https",
@@ -11,52 +5,5 @@ geo = new GeoCoder(
 )
 
 Meteor.methods
-  createSurvey: (fields) ->
-    @unblock()
-    unless @userId then throw new Meteor.Error(500, 'Not Authorized')
-    if not fields?.title or fields.title.length == 0
-      throw new Meteor.Error(501, 'The title field cannot be empty')
-    fields.createdBy = @userId
-    survey = new Survey()
-    survey.save(fields).then (survey) ->
-      survey.id
-    , handleError
-
-  createForm: (surveyId, props) ->
-    @unblock()
-    unless @userId then throw new Meteor.Error(500, 'Not Authorized')
-    #TODO Validate
-    query = new Parse.Query Survey
-    query.get(surveyId).then (survey) ->
-      survey.addForm(props).then (formId) ->
-        formId
-      , handleError
-    , handleError
-
   geocode: (address) ->
     geo.geocode(address)
-
-  editForm: (formId, props) ->
-    @unblock()
-    unless @userId then throw new Meteor.Error(500, 'Not Authorized')
-    query = new Parse.Query Form
-    query.get(formId).then (form) ->
-      form.update(props).then (form) ->
-        form
-      , handleError
-    , handleError
-
-  updateForm: (formId, form) ->
-    @unblock()
-    unless @userId then throw new Meteor.Error(500, 'Not Authorized')
-    getForms().update(_id: formId, { $set: form })
-
-  createQuestion: (formId, props) ->
-    @unblock()
-    unless @userId then throw new Meteor.Error(500, 'Not Authorized')
-    query = new Parse.Query Form
-    query.get(formId).then (form) ->
-      form.addQuestion(props).then (questionId) ->
-        questionId
-      , handleError
-    , handleError


### PR DESCRIPTION
This is being done because the parse user is only logged in client side so Parse calls on the server side can't use access control.