### PR TITLE
Cascading deletion

### DIFF
--- a/app/packages/_models/models.coffee
+++ b/app/packages/_models/models.coffee
@@ -50,6 +50,14 @@ Survey = Parse.Object.extend 'Survey',
       .then ->
         form
 
+  remove: ->
+    survey = @
+    @getForms()
+      .then (forms) ->
+        _.each forms, (form) -> form.remove()
+      .then ->
+        survey.destroy()
+
 Form = Parse.Object.extend 'Form',
   create: (props) ->
     form = @
@@ -123,6 +131,18 @@ Form = Parse.Object.extend 'Form',
   updateTrigger: (props) ->
     @getTrigger().then (trigger) ->
       trigger.update props
+
+  remove: ->
+    form = @
+    @getTrigger()
+      .then (trigger) ->
+        trigger.destroy()
+      .then ->
+        form.getQuestions()
+      .then (questions) ->
+        _.each questions, (question) -> question.destroy()
+      .then ->
+        form.destroy()
 
 Trigger = Parse.Object.extend 'Trigger',
   create: (props, form) ->

--- a/app/packages/_styles/globals.styl
+++ b/app/packages/_styles/globals.styl
@@ -2,7 +2,19 @@
   .delete
   .edit
     padding 5px 10px
-  .delete
-    color white
   .edit
     color #666
+
+
+.actions
+  position absolute
+  right 15px
+  top 50%
+  transform translate(0, -50%)
+  .action
+    display inline-block
+    margin-right 5px
+    &:last-of-type
+      margin 0
+    &:hover
+      cursor pointer

--- a/app/packages/forms/controllers/form_details.coffee
+++ b/app/packages/forms/controllers/form_details.coffee
@@ -17,10 +17,10 @@ Template.form_details.helpers
     Template.instance().questionCollection
 
 Template.form_details.events
- 'click .delete': (event, instance) ->
+ 'click .delete-form': (event, instance) ->
    survey = instance.survey
    survey.getForm(instance.data.formId)
     .then (form) ->
-      form.remove()
+      form.delete()
     .then ->
       FlowRouter.go "/admin/surveys/#{survey.id}"

--- a/app/packages/forms/controllers/form_details.coffee
+++ b/app/packages/forms/controllers/form_details.coffee
@@ -1,9 +1,9 @@
 Template.form_details.onCreated ->
   @fetched = new ReactiveVar false
   @questionCollection = new Meteor.Collection null
-  survey = @data.survey
+  @survey = @data.survey
   instance = @
-  survey.getForm(@data.formId)
+  @survey.getForm(@data.formId)
     .then (form) ->
       instance.form = form
       instance.fetched.set true
@@ -15,3 +15,12 @@ Template.form_details.helpers
     Template.instance().form
   questionsCollection: ->
     Template.instance().questionCollection
+
+Template.form_details.events
+ 'click .delete': (event, instance) ->
+   survey = instance.survey
+   survey.getForm(instance.data.formId)
+    .then (form) ->
+      form.remove()
+    .then ->
+      FlowRouter.go "/admin/surveys/#{survey.id}"

--- a/app/packages/forms/controllers/form_edit.coffee
+++ b/app/packages/forms/controllers/form_edit.coffee
@@ -311,11 +311,11 @@ Template.form_edit.events
         .fail (error) ->
           toastr.error error.message
 
-  'click .delete': (event, instance) ->
+  'click .delete-form': (event, instance) ->
     survey = instance.survey
     survey.getForm(instance.formId)
       .then (form) ->
-        form.remove()
+        form.delete()
       .then ->
         FlowRouter.go "/admin/surveys/#{survey.id}"
 

--- a/app/packages/forms/controllers/form_edit.coffee
+++ b/app/packages/forms/controllers/form_edit.coffee
@@ -311,6 +311,14 @@ Template.form_edit.events
         .fail (error) ->
           toastr.error error.message
 
+  'click .delete': (event, instance) ->
+    survey = instance.survey
+    survey.getForm(instance.formId)
+      .then (form) ->
+        form.remove()
+      .then ->
+        FlowRouter.go "/admin/surveys/#{survey.id}"
+
 Template.form_edit.onRendered ->
   # the map is recreated each time the page is rendered, so clear any old
   # marker/shape

--- a/app/packages/forms/controllers/forms.coffee
+++ b/app/packages/forms/controllers/forms.coffee
@@ -29,10 +29,10 @@ Template.forms.helpers
     Template.instance().data.survey.id
 
 Template.forms.events
- 'click .delete': (event, instance) ->
+ 'click .delete-form': (event, instance) ->
    form = @
    instance.survey.getForm(@parseId)
     .then (form) ->
-      form.remove()
+      form.delete()
     .then ->
       instance.forms.remove form._id

--- a/app/packages/forms/controllers/forms.coffee
+++ b/app/packages/forms/controllers/forms.coffee
@@ -27,3 +27,12 @@ Template.forms.helpers
     Template.instance().forms?.findOne()
   surveyId: ->
     Template.instance().data.survey.id
+
+Template.forms.events
+ 'click .delete': (event, instance) ->
+   form = @
+   instance.survey.getForm(@parseId)
+    .then (form) ->
+      form.remove()
+    .then ->
+      instance.forms.remove form._id

--- a/app/packages/forms/views/form_details.jade
+++ b/app/packages/forms/views/form_details.jade
@@ -7,7 +7,7 @@ template(name="form_details")
             i.mdi.mdi-arrow-left-bold-circle-outline
           h4=form.attributes.title
           a.btn.btn-default(href="#{formId}/edit") Edit
-          a.btn.btn-danger.delete Delete
+          a.btn.btn-danger.delete.delete-form Delete
         .form--details
           .row
             .col-md-4

--- a/app/packages/forms/views/form_details.jade
+++ b/app/packages/forms/views/form_details.jade
@@ -7,7 +7,7 @@ template(name="form_details")
             i.mdi.mdi-arrow-left-bold-circle-outline
           h4=form.attributes.title
           a.btn.btn-default(href="#{formId}/edit") Edit
-
+          a.btn.btn-danger.delete Delete
         .form--details
           .row
             .col-md-4

--- a/app/packages/forms/views/form_edit.jade
+++ b/app/packages/forms/views/form_edit.jade
@@ -1,6 +1,7 @@
 template(name="form_edit")
   .survey-admin--content
     if fetched
+      a.btn.btn-danger.delete.pull-right Delete
       form.edit-form
         .form-group
           .row

--- a/app/packages/forms/views/form_edit.jade
+++ b/app/packages/forms/views/form_edit.jade
@@ -1,7 +1,7 @@
 template(name="form_edit")
   .survey-admin--content
     if fetched
-      a.btn.btn-danger.delete.pull-right Delete
+      a.btn.btn-danger.delete.delete-form.pull-right Delete
       form.edit-form
         .form-group
           .row

--- a/app/packages/forms/views/forms.jade
+++ b/app/packages/forms/views/forms.jade
@@ -13,6 +13,8 @@ template(name="forms")
               span.sortable-handle
                 i.mdi.mdi-drag
               a(href="{{pathFor 'form_details' id=surveyId formId=parseId}}")=title
-              a.btn.btn-default.edit(href="forms/#{parseId}/edit") Edit
+              .actions
+                a.btn.btn-default.action.edit(href="forms/#{parseId}/edit") Edit
+                a.btn.btn-danger.action.delete Delete
       else
         p This survey has no forms

--- a/app/packages/forms/views/forms.jade
+++ b/app/packages/forms/views/forms.jade
@@ -15,6 +15,6 @@ template(name="forms")
               a(href="{{pathFor 'form_details' id=surveyId formId=parseId}}")=title
               .actions
                 a.btn.btn-default.action.edit(href="forms/#{parseId}/edit") Edit
-                a.btn.btn-danger.action.delete Delete
+                a.btn.btn-danger.action.delete.delete-form Delete
       else
         p This survey has no forms

--- a/app/packages/layout/styles/main.styl
+++ b/app/packages/layout/styles/main.styl
@@ -11,17 +11,6 @@
   background #f9f9f9
   box-shadow inset 0 0 5px rgba(0,0,0,.05)
 
-.delete
-.edit
-  position absolute
-  right 15px
-  top 50%
-  transform translate(0, -50%)
-  color #D9534F
-  &:hover
-    cursor pointer
-    color darken(@color, 15%)
-
 .list-group-item
   span
     vertical-align middle

--- a/app/packages/questions/controllers/questions.coffee
+++ b/app/packages/questions/controllers/questions.coffee
@@ -33,8 +33,10 @@ Template.questions.helpers
     Template.instance().questions?.find {}, sort: {order: 1}
 
 Template.questions.events
-  'click .delete': (event, instance) ->
+  'click .delete-question': (event, instance) ->
     query = new Parse.Query Question
-    query.get(@parseId).then (question) =>
-      question.destroy().then () =>
+    query.get(@parseId)
+      .then (question) =>
+        question.delete()
+      .then () =>
         instance.questions.remove @_id

--- a/app/packages/questions/views/questions.jade
+++ b/app/packages/questions/views/questions.jade
@@ -11,7 +11,7 @@ template(name="questions")
                 i.mdi.mdi-drag
               a(href="{{pathFor 'questions_edit' id=surveyId formId=formId questionId=parseId}}")= text
               .actions
-                .action.delete.warning(data-id=parseId)
+                .action.delete-question.warning(data-id=parseId)
                   i.mdi.mdi-delete
       else
         .panel-body

--- a/app/packages/questions/views/questions.jade
+++ b/app/packages/questions/views/questions.jade
@@ -10,8 +10,9 @@ template(name="questions")
               span.sortable-handle
                 i.mdi.mdi-drag
               a(href="{{pathFor 'questions_edit' id=surveyId formId=formId questionId=parseId}}")= text
-              .delete.warning(data-id=parseId)
-                i.mdi.mdi-delete
+              .actions
+                .action.delete.warning(data-id=parseId)
+                  i.mdi.mdi-delete
       else
         .panel-body
           p No questions specified

--- a/app/packages/surveys/controllers/create_survey_modal.coffee
+++ b/app/packages/surveys/controllers/create_survey_modal.coffee
@@ -14,6 +14,7 @@ Template.create_survey_modal.events
     surveyProps = _.object $(event.target).serializeArray().map(
       ({name, value})-> [name, value]
     )
+    surveyProps.deleted = false
     surveyProps.createdBy = Parse.User.current()
     survey = new Survey()
     survey.save(surveyProps)

--- a/app/packages/surveys/controllers/delete_survey_modal.coffee
+++ b/app/packages/surveys/controllers/delete_survey_modal.coffee
@@ -18,7 +18,7 @@ Template.delete_survey_modal.events
     query = new Parse.Query Survey
     query.get(instance.surveyId)
       .then (survey) ->
-        survey.destroy()
+        survey.remove()
       .then (obj) ->
         $('#delete-survey-modal').modal('hide')
         instance.deleting.set false

--- a/app/packages/surveys/controllers/delete_survey_modal.coffee
+++ b/app/packages/surveys/controllers/delete_survey_modal.coffee
@@ -18,7 +18,7 @@ Template.delete_survey_modal.events
     query = new Parse.Query Survey
     query.get(instance.surveyId)
       .then (survey) ->
-        survey.remove()
+        survey.delete()
       .then (obj) ->
         $('#delete-survey-modal').modal('hide')
         instance.deleting.set false

--- a/app/packages/surveys/controllers/surveys.coffee
+++ b/app/packages/surveys/controllers/surveys.coffee
@@ -5,18 +5,18 @@ Template.surveys.onCreated ->
   @surveys = new Meteor.Collection null
 
 Template.surveys.onRendered ->
-  self = this
-  surveyQuery = new Parse.Query Survey
-  surveyQuery.find().then (surveys) ->
-    self.fetched.set true
+  instance = @
+  query = new Parse.Query Survey
+  query.equalTo 'deleted', false
+  query.find().then (surveys) ->
+    instance.fetched.set true
     _.each surveys, (survey) ->
       surveyProps =
         parseId: survey.id
         title: survey.get 'title'
-      self.surveys.insert surveyProps
+      instance.surveys.insert surveyProps
   , (error) ->
     throw new Meteor.Error 'server', error.message
-
 
 Template.surveys.helpers
   surveys: ->

--- a/app/packages/surveys/views/surveys.jade
+++ b/app/packages/surveys/views/surveys.jade
@@ -10,11 +10,12 @@ template(name="surveys")
           each surveys
             li.list-group-item.form-link
               a(href="{{pathFor 'survey_details' id=parseId}}")= title
-              a.btn.btn-danger.delete(
-                data-toggle="modal"
-                data-target="#delete-survey-modal"
-                data-id=parseId)
-                | Delete
+              .actions
+                a.btn.btn-danger.action.delete(
+                  data-toggle="modal"
+                  data-target="#delete-survey-modal"
+                  data-id=parseId)
+                  | Delete
 
     +create_survey_modal survey=surveyCollection
     +delete_survey_modal surveys=surveyCollection


### PR DESCRIPTION
Adds a few methods to take care of cascading deletion. Ideally this should be done in an `afterDelete` Cloud code function but Freddie and I had trouble getting the functions to run on the parse server. We can come back to it at a later date.
I also went ahead and added form deletion which just uses the `remove` method on the `Form` class and adds buttons to each related template.

We will probably need to improve the user experience until things are moved to the server. If a user deletes a bunch of stuff, there will be a lag and currently the user will be left unaware as to what is causing the lag.

PT Chore: https://www.pivotaltracker.com/story/show/119379991
PT Story: https://www.pivotaltracker.com/story/show/119526279