### PR TITLE
Update make file - prepend npm commands with "meteor"

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,6 +1,12 @@
+all:
+	@echo "run:			meteor npm start"
+	@echo "parse-server:		meteor npm run server"
+	@echo "run-test:		meteor npm run test"
+	@echo "test-watch:		meteor npm run test-watch"
+
 # Dev server
 run:
-	npm run start
+	meteor npm start
 
 # Dev server (test mode)
 run-test:
@@ -8,12 +14,12 @@ run-test:
 
 # Local Parse server
 parse-server:
-	npm run server
+	meteor npm run server
 
 # Acceptance test
-test:
-	npm run test
+run-test:
+	meteor npm test
 
 # Acceptance test (watch)
 test-watch:
-	npm run test-watch
+	meteor npm test-watch


### PR DESCRIPTION
I did some digging on the issue of Node overloading our CPUs mostly because I'm tired of stressing out my machine. Found this: https://github.com/meteor/meteor/issues/4314 Looks like meteor is using an old version of node which is causing issues. Sounds like they plan on updating soon.

So when you run apps using the `npm` you should prepend with `meteor` like so: `meteor npm start`
This PR updates the make file with the above change.