### PR TITLE
ACLs on all objects

### DIFF
--- a/app/packages/_api/form.coffee
+++ b/app/packages/_api/form.coffee
@@ -1,6 +1,6 @@
 Trigger = require './trigger'
 Question = require './question'
-{ buildMeteorCollection } = require 'meteor/gq:helpers'
+{ buildMeteorCollection, setAdminACL } = require 'meteor/gq:helpers'
 
 Form = Parse.Object.extend 'Form',
   create: (props) ->
@@ -9,11 +9,15 @@ Form = Parse.Object.extend 'Form',
     # so they aren't saved to form
     triggerProps = props.trigger
     delete props.trigger
-    @save(props)
+    setAdminACL(form)
+      .then ->
+        form.save(props)
       .then ->
         form.addTrigger(triggerProps)
       .then ->
         form
+      .fail (err) ->
+        console.log err
 
   getQuestions: (returnMeteorCollection, collection, limit) ->
     query = @relation('questions').query()

--- a/app/packages/_api/form.coffee
+++ b/app/packages/_api/form.coffee
@@ -1,6 +1,6 @@
 Trigger = require './trigger'
 Question = require './question'
-{ buildMeteorCollection, setAdminACL } = require 'meteor/gq:helpers'
+{ buildMeteorCollection, setAdminACL, setUserACL } = require 'meteor/gq:helpers'
 
 Form = Parse.Object.extend 'Form',
   create: (props) ->
@@ -104,7 +104,7 @@ Form = Parse.Object.extend 'Form',
       .then (trigger) ->
         form.getQuestions()
       .then (questions) ->
-        _.each questions, (question) ->
+        questions.forEach (question) ->
           question.delete(deleted)
       .then ->
         form.set 'deleted', deleted
@@ -124,5 +124,23 @@ Form = Parse.Object.extend 'Form',
         _.each questions, (question) -> question.destroy()
       .then ->
         form.destroy()
+
+  setUserACL: (user, access) ->
+    form = @
+    setUserACL form, user, access
+    form.save()
+      .then ->
+        form.getTrigger()
+      .then (trigger) ->
+        setUserACL trigger, user, access
+        trigger.save()
+      .then ->
+        form.getQuestions()
+      .then (questions) ->
+        questions.forEach (question) ->
+          setUserACL question, user, access
+          question.save()
+      .fail (err) ->
+        console.log err
 
 module.exports = Form

--- a/app/packages/_api/question.coffee
+++ b/app/packages/_api/question.coffee
@@ -1,9 +1,13 @@
+{ setAdminACL } = require 'meteor/gq:helpers'
+
 Question = Parse.Object.extend 'Question',
   create: (props, lastQuestionOrder, form) ->
     question = @
     props.order = ++lastQuestionOrder or 1
     props.createdBy = Parse.User.current()
-    question.save(props)
+    setAdminACL(question)
+      .then ->
+        question.save(props)
       .then ->
         question.addToForm(form)
       .then ->

--- a/app/packages/_api/survey.coffee
+++ b/app/packages/_api/survey.coffee
@@ -1,11 +1,16 @@
 Form = require './form'
-{ buildMeteorCollection } = require 'meteor/gq:helpers'
+{ buildMeteorCollection, setAdminACL } = require 'meteor/gq:helpers'
 
 Survey = Parse.Object.extend 'Survey',
   validate: (props) ->
     if props?.title?.length == 0
       return new Parse.Error(Parse.VALIDATION_ERROR, 'The title field cannot be empty')
     Parse.Object.prototype.validate.call(this, props)
+
+  create: (props) ->
+    setAdminACL(@)
+      .then =>
+        @save props
 
   getForms: (returnMeteorCollection, collection, limit) ->
     query = @relation('forms').query()

--- a/app/packages/_api/survey.coffee
+++ b/app/packages/_api/survey.coffee
@@ -1,5 +1,5 @@
 Form = require './form'
-{ buildMeteorCollection, setAdminACL } = require 'meteor/gq:helpers'
+{ buildMeteorCollection, setAdminACL, setUserACL } = require 'meteor/gq:helpers'
 
 Survey = Parse.Object.extend 'Survey',
   validate: (props) ->
@@ -103,5 +103,25 @@ Survey = Parse.Object.extend 'Survey',
         _.each forms, (form) -> form.remove()
       .then ->
         survey.destroy()
+
+  ###
+    Set read rights of a user
+    @param [Boolean] access, Rights
+  ###
+  setUserACL: (access) ->
+    survey = @
+    query = @relation('invitedUsers').query()
+    query.find()
+      .then (users) ->
+        users.forEach (user) ->
+          setUserACL survey, user, access
+          survey.save()
+            .then ->
+              survey.getForms()
+            .then (forms) ->
+              forms.forEach (form) ->
+                form.setUserACL user, access
+            .fail (err) ->
+              console.log err
 
 module.exports = Survey

--- a/app/packages/_api/trigger.coffee
+++ b/app/packages/_api/trigger.coffee
@@ -1,8 +1,12 @@
+{ setAdminACL } = require 'meteor/gq:helpers'
+
 Trigger = Parse.Object.extend 'Trigger',
   create: (props, form) ->
     trigger = @
-    @setProperties props
-    @save()
+    trigger.setProperties props
+    setAdminACL(trigger)
+      .then ->
+        trigger.save()
       .then ->
         trigger.addToForm(form)
       .then ->

--- a/app/packages/_helpers/helpers.coffee
+++ b/app/packages/_helpers/helpers.coffee
@@ -67,6 +67,7 @@ transformObj = (obj) ->
 ###
   Accepts Parse object and sets ACL giving users in Admin Role read/write access
   @param [Object] obj, Parse object on which to modify ACL
+  @return [Promise]
 ###
 setAdminACL = (obj) ->
   acl = if obj.isNew() then new Parse.ACL() else acl = obj.getACL()
@@ -74,14 +75,28 @@ setAdminACL = (obj) ->
   query.equalTo 'name', 'admin'
   query.first()
     .then (adminRole) ->
+      acl.setPublicReadAccess false
+      acl.setPublicWriteAccess false
       acl.setReadAccess adminRole, true
       acl.setWriteAccess adminRole, true
       obj.setACL acl
     .fail (err) ->
       console.log err
 
+###
+  Accepts Parse object and sets ACL giving users in Admin Role read/write access
+  @param [Object] obj, Parse object on which to modify ACL
+  @param [Object] user, Parse User to add to ACL
+###
+setUserACL = (obj, user) ->
+  acl = obj.getACL()
+  acl.setReadAccess(user, true)
+  obj.setACL(acl)
+
+
 module.exports =
   buildMeteorCollection: buildMeteorCollection
   updateSortOrder      : updateSortOrder
   transformObj         : transformObj
   setAdminACL          : setAdminACL
+  setUserACL           : setUserACL

--- a/app/packages/_helpers/helpers.coffee
+++ b/app/packages/_helpers/helpers.coffee
@@ -43,8 +43,8 @@ updateSortOrder = (event, parentObj, relatedObjString) ->
 ###
   Accpets an array of Parse objects and returns a Meteor Collection
   of documents containing the Parse object's attributes and id
-  @param [Array] objs, Parse objects
-  @param [Object] collection, Meteor Collection to contain Parse objects
+  @param [Array]   objs, Parse objects
+  @param [Object]  collection, Meteor Collection to contain Parse objects
   @return [Object] Meteor collection of Parse objects
 ###
 buildMeteorCollection = (objs, collection) ->
@@ -56,7 +56,7 @@ buildMeteorCollection = (objs, collection) ->
   objCollection
 
 ###
-  @param [Object] obj, Parse object to transform
+  @param [Object]  obj, Parse object to transform
   @return [Object] Object containing Parse object's attrs including id as parseId
 ###
 transformObj = (obj) ->
@@ -84,13 +84,14 @@ setAdminACL = (obj) ->
       console.log err
 
 ###
-  Accepts Parse object and sets ACL giving users in Admin Role read/write access
-  @param [Object] obj, Parse object on which to modify ACL
-  @param [Object] user, Parse User to add to ACL
+  Sets ACL giving giving user read access to Parse obj
+  @param [Object]   obj, Parse object on which to modify ACL
+  @param [Object]   user, Parse User to add to ACL
+  @param [Boolean]  access [true], Access rights
 ###
-setUserACL = (obj, user) ->
+setUserACL = (obj, user, access=true) ->
   acl = obj.getACL()
-  acl.setReadAccess(user, true)
+  acl.setReadAccess(user, access)
   obj.setACL(acl)
 
 

--- a/app/packages/_helpers/helpers.coffee
+++ b/app/packages/_helpers/helpers.coffee
@@ -56,7 +56,7 @@ buildMeteorCollection = (objs, collection) ->
   objCollection
 
 ###
-  @param [Object] Parse object to transform
+  @param [Object] obj, Parse object to transform
   @return [Object] Object containing Parse object's attrs including id as parseId
 ###
 transformObj = (obj) ->
@@ -64,7 +64,24 @@ transformObj = (obj) ->
   props.parseId = obj.id
   props
 
+###
+  Accepts Parse object and sets ACL giving users in Admin Role read/write access
+  @param [Object] obj, Parse object on which to modify ACL
+###
+setAdminACL = (obj) ->
+  acl = if obj.isNew() then new Parse.ACL() else acl = obj.getACL()
+  query = new Parse.Query Parse.Role
+  query.equalTo 'name', 'admin'
+  query.first()
+    .then (adminRole) ->
+      acl.setReadAccess adminRole, true
+      acl.setWriteAccess adminRole, true
+      obj.setACL acl
+    .fail (err) ->
+      console.log err
+
 module.exports =
   buildMeteorCollection: buildMeteorCollection
   updateSortOrder      : updateSortOrder
   transformObj         : transformObj
+  setAdminACL          : setAdminACL

--- a/app/packages/_helpers/helpers.coffee
+++ b/app/packages/_helpers/helpers.coffee
@@ -94,6 +94,14 @@ setUserACL = (obj, user, access=true) ->
   acl.setReadAccess(user, access)
   obj.setACL(acl)
 
+###
+  @param [String] Role for which to search
+  @return [Promise] Role
+###
+getRole = (role) ->
+  query = new Parse.Query Parse.Role
+  query.equalTo 'name', role
+  query.first()
 
 module.exports =
   buildMeteorCollection: buildMeteorCollection
@@ -101,3 +109,4 @@ module.exports =
   transformObj         : transformObj
   setAdminACL          : setAdminACL
   setUserACL           : setUserACL
+  getRole              : getRole

--- a/app/packages/openam/package.js
+++ b/app/packages/openam/package.js
@@ -9,6 +9,7 @@ Package.onUse(function (api) {
   api.versionsFrom('1.2.1');
 
   api.use('coffeescript');
+  api.use('ecmascript');
 
   api.use('kadira:flow-router', 'client');
   api.use('stylus', 'client');

--- a/app/packages/openam/signup.coffee
+++ b/app/packages/openam/signup.coffee
@@ -1,3 +1,5 @@
+{ getRole } = require 'meteor/gq:helpers'
+
 Template.signup.events
   'submit form': (event, instance) ->
     event.preventDefault()
@@ -23,9 +25,7 @@ Template.signup.events
         .then ->
           Parse.User.become(currentUserSessionToken)
         .then ->
-          query = new Parse.Query(Parse.Role)
-          query.equalTo("name", "admin")
-          query.first()
+          getRole('admin')
         .then (adminRole)->
           adminRole.relation("users").add(parseUser)
           adminRole.save()

--- a/app/packages/surveys/controllers/edit_survey_modal.coffee
+++ b/app/packages/surveys/controllers/edit_survey_modal.coffee
@@ -57,7 +57,7 @@ Template.edit_survey_modal.events
       surveyProps.deleted = false
       surveyProps.active = false
       survey = new Survey()
-      survey.save(surveyProps)
+      survey.create(surveyProps)
         .then (survey) ->
           afterSurveySave(true, survey, instance, event)
         .fail (error) ->

--- a/app/packages/surveys/controllers/survey_details.coffee
+++ b/app/packages/surveys/controllers/survey_details.coffee
@@ -49,7 +49,8 @@ Template.survey_details.events
     activeState.set not activeState.get()
     props =
       active: activeState.get()
-    instance.survey.save(props).then (survey) ->
-      state = (if activeState.get() then "activated" else "deactivated")
-      toastr.success("You have " + state + " your survey.")
-      FlowRouter.go("/admin/surveys/#{instance.survey.id}")
+    instance.survey.save(props)
+      .then (survey) ->
+        state = (if activeState.get() then "activated" else "deactivated")
+        toastr.success("You have " + state + " your survey.")
+        FlowRouter.go("/admin/surveys/#{instance.survey.id}")

--- a/app/packages/surveys/controllers/survey_user_edit.coffee
+++ b/app/packages/surveys/controllers/survey_user_edit.coffee
@@ -1,4 +1,4 @@
-{ setAdminACL, setUserACL } = require 'meteor/gq:helpers'
+{ setAdminACL, setUserACL, getRole } = require 'meteor/gq:helpers'
 
 Template.survey_user_edit.onRendered ->
   @survey = @data.survey
@@ -27,6 +27,7 @@ Template.survey_user_edit.events
               user.set 'username', userProps.username
               user.set 'email', userProps.username
               user.set 'password', userProps.password
+              user.set 'role', 'user'
               user.signUp()
       .then (user)->
         newUser = user
@@ -35,9 +36,7 @@ Template.survey_user_edit.events
         survey.relation('invitedUsers').add(newUser)
         survey.save()
       .then ->
-        query = new Parse.Query Parse.Role
-        query.equalTo "name", "user"
-        query.first()
+        getRole('user')
       .then (role)->
         role.relation("users").add(newUser)
         role.save()

--- a/app/packages/surveys/controllers/survey_user_edit.coffee
+++ b/app/packages/surveys/controllers/survey_user_edit.coffee
@@ -20,12 +20,7 @@ Template.survey_user_edit.events
         else
           Parse.User.signUp(userProps.username, userProps.password, userProps)
       .then (user)->
-        newUser = user
-        Parse.User.become(currentUserSessionToken)
-        query = new Parse.Query(Parse.Role)
-        query.equalTo("name", "admin")
-        query.first()
-      .then (adminRole)->
+        # check for relation
         instance.survey.relation('invitedUsers').add(newUser)
         acl = instance.survey.getACL()
         acl.setReadAccess(newUser, true)

--- a/app/packages/surveys/controllers/survey_user_edit.coffee
+++ b/app/packages/surveys/controllers/survey_user_edit.coffee
@@ -33,7 +33,6 @@ Template.survey_user_edit.events
         Parse.User.become(currentUserSessionToken)
       .then ->
         survey.relation('invitedUsers').add(newUser)
-        setUserACL survey, newUser
         survey.save()
       .then ->
         query = new Parse.Query Parse.Role

--- a/app/packages/surveys/controllers/survey_users.coffee
+++ b/app/packages/surveys/controllers/survey_users.coffee
@@ -1,19 +1,21 @@
 Template.survey_users.onCreated ->
-  @users = new Meteor.Collection(null)
   @fetched = new ReactiveVar false
 Template.survey_users.onRendered ->
   @survey = @data.survey
   @fetched.set false
-  @users.remove {}
-  @survey.relation('invitedUsers').query().find()
-    .then (result) =>
-      result.forEach (item) =>
-        @users.insert item.toJSON()
-    .fail (err) ->
-      toastr.error err.message
-    .always =>
-      @fetched.set true
+  if @survey.has 'invitedUsers'
+    @users = new Meteor.Collection(null)
+    @survey.relation('invitedUsers').query().find()
+      .then (result) =>
+        result.forEach (item)=>
+          @users.insert item.toJSON()
+      .fail (err)->
+        toastr.error err.message
+      .always =>
+        @fetched.set true
+  else
+    @fetched.set true
 
 Template.survey_users.helpers
   users: ->
-    Template.instance().users.find()
+    Template.instance().users?.find()

--- a/app/packages/surveys/views/survey_details.jade
+++ b/app/packages/surveys/views/survey_details.jade
@@ -4,8 +4,11 @@ template(name="survey_details")
     .survey--details
       if fetched
         p.description= survey.description
-        button.btn.btn-primary.activate
-          span(class='{{activateButtonClass}}').mdi
+        button.btn.btn-primary.activate(disabled="{{#if activating}} true {{/if}}")
+          if activating
+            span.fa.fa-spinner.fa-pulse
+          else
+            span(class='{{activateButtonClass}}').mdi
           span
             =activateButtonText
             | Survey


### PR DESCRIPTION
- Locks down objects on creation by setting up an ACL giving read/write access only to admin users
- Adds methods to add users to ACL with read-only acccess of all related/child objects of a a survey
- When user activates/deactivates survey user rights are given/revoked
