### PR TITLE
Stop prefixing routes with "admin"

### DIFF
--- a/app/packages/_router/routes.coffee
+++ b/app/packages/_router/routes.coffee
@@ -5,12 +5,11 @@ if Meteor.isClient
 FlowRouter.route '/',
   action: ->
     if Meteor.user()
-      FlowRouter.go '/admin/surveys'
+      FlowRouter.go '/surveys'
     else
       FlowRouter.go 'login'
 
 adminRoutes = FlowRouter.group
-  prefix: '/admin'
   name: 'admin'
   triggersEnter: [ ->
     unless Meteor.loggingIn() or Meteor.userId()

--- a/app/packages/forms/controllers/form_details.coffee
+++ b/app/packages/forms/controllers/form_details.coffee
@@ -23,4 +23,4 @@ Template.form_details.events
     .then (form) ->
       form.delete()
     .then ->
-      FlowRouter.go "/admin/surveys/#{survey.id}"
+      FlowRouter.go "/surveys/#{survey.id}"

--- a/app/packages/forms/controllers/form_edit.coffee
+++ b/app/packages/forms/controllers/form_edit.coffee
@@ -222,7 +222,7 @@ Template.form_edit.events
 
   'click #cancelForm': (event, instance) ->
     # upon canceling, go to the list
-    FlowRouter.go("/admin/surveys/#{instance.survey.id}/forms")
+    FlowRouter.go("/surveys/#{instance.survey.id}/forms")
 
   'keyup #searchAddress': (event, instance) ->
     q = getAddress()
@@ -309,13 +309,13 @@ Template.form_edit.events
     if form
       form.update(props)
         .then ->
-          FlowRouter.go "/admin/surveys/#{instance.survey.id}/forms"
+          FlowRouter.go "/surveys/#{instance.survey.id}/forms"
         .fail (error) ->
           toastr.error error.message
     else
       instance.survey.addForm(props)
         .then (form) ->
-          FlowRouter.go "/admin/surveys/#{instance.survey.id}/forms/#{form.id}"
+          FlowRouter.go "/surveys/#{instance.survey.id}/forms/#{form.id}"
         .fail (error) ->
           toastr.error error.message
 
@@ -325,7 +325,7 @@ Template.form_edit.events
       .then (form) ->
         form.delete()
       .then ->
-        FlowRouter.go "/admin/surveys/#{survey.id}"
+        FlowRouter.go "/surveys/#{survey.id}"
 
 Template.form_edit.onRendered ->
   # the map is recreated each time the page is rendered, so clear any old

--- a/app/packages/layout/views/header.jade
+++ b/app/packages/layout/views/header.jade
@@ -8,6 +8,6 @@ template(name="header")
         #navbar.navbar-collapse.collapse
           ul.nav.navbar-nav.navbar-right
             li
-              a(href="/admin/signup") Admins
+              a(href="/signup") Admins
             li
               a#logout(href="/logout") Sign Out

--- a/app/packages/openam/routes.coffee
+++ b/app/packages/openam/routes.coffee
@@ -3,7 +3,7 @@ Meteor.startup ->
     if Meteor.userId()
       curentPath = FlowRouter.current().path
       if curentPath == '/login'
-        FlowRouter.go '/admin/surveys'
+        FlowRouter.go '/surveys'
       else
         FlowRouter.go curentPath
     else
@@ -13,7 +13,6 @@ Meteor.startup ->
 exposed = FlowRouter.group {}
 
 adminRoutes = FlowRouter.group
-  prefix: '/admin'
   name: 'admin'
   triggersEnter: [ ->
     unless Meteor.loggingIn() or Meteor.userId()

--- a/app/packages/questions/controllers/questions_edit.coffee
+++ b/app/packages/questions/controllers/questions_edit.coffee
@@ -126,7 +126,7 @@ Template.questions_edit.events
 
     instance.question.get().save(question).then ->
       data = instance.data
-      FlowRouter.go("/admin/surveys/#{data.id}/forms/#{data.formId}")
+      FlowRouter.go("/surveys/#{data.id}/forms/#{data.formId}")
 
   'click .add-choice': (event, instance)->
     instance.choices.insert {}

--- a/app/packages/surveys/controllers/edit_survey_modal.coffee
+++ b/app/packages/surveys/controllers/edit_survey_modal.coffee
@@ -29,7 +29,7 @@ afterSurveySave = (isNewSurvey, survey, instance, event) ->
     window.setTimeout(->
       # Wait for modal to hide so the backdrop won't get stuck open.
       toastr.success 'Success'
-      FlowRouter.go '/admin/surveys/' + survey.id
+      FlowRouter.go '/surveys/' + survey.id
     , 300)
   else
     # Update the existing details

--- a/app/packages/surveys/controllers/survey_details.coffee
+++ b/app/packages/surveys/controllers/survey_details.coffee
@@ -62,4 +62,4 @@ Template.survey_details.events
         instance.activating.set false
         state = (if activeState.get() then "activated" else "deactivated")
         toastr.success("You have " + state + " your survey.")
-        FlowRouter.go("/admin/surveys/#{instance.survey.id}")
+        FlowRouter.go("/surveys/#{instance.survey.id}")

--- a/app/packages/surveys/controllers/survey_user_edit.coffee
+++ b/app/packages/surveys/controllers/survey_user_edit.coffee
@@ -42,10 +42,10 @@ Template.survey_user_edit.events
         role.save()
       .then ->
         toastr.success("User added")
-        FlowRouter.go("/admin/surveys/#{survey.id}/users")
+        FlowRouter.go("/surveys/#{survey.id}/users")
       .fail (err)->
         console.error(err)
         toastr.error(err.message)
 
   'click #cancel': (event, instance) ->
-    FlowRouter.go("/admin/surveys/#{instance.survey.id}/users")
+    FlowRouter.go("/surveys/#{instance.survey.id}/users")


### PR DESCRIPTION
Removes the 'admin/' prefix from routes.
At this point, since its an admin-only app, we don't need the prefix (I don't think we will even if we allow regular users to login)
