### PR TITLE
Fix reactivity associated with survey state

### DIFF
--- a/app/packages/_helpers/template_helpers.coffee
+++ b/app/packages/_helpers/template_helpers.coffee
@@ -3,8 +3,8 @@ Template.registerHelper 'fetched', ->
 
 Template.registerHelper 'surveyIsActive', ->
   instance = Template.instance()
-  survey = instance.survey or instance.data.survey
-  survey?.get 'active'
+  surveyState = instance.surveyState or instance.data.surveyState
+  surveyState.get()
 
 Template.registerHelper 'match', (val, {hash:{regex}})->
   val?.match new RegExp regex

--- a/app/packages/forms/views/form_details.jade
+++ b/app/packages/forms/views/form_details.jade
@@ -4,6 +4,7 @@ template(name="form_details")
       +form_header(
         path='forms'
         id=survey.id
+        surveyState=surveyState
         classNames='small'
         form=form
         survey=survey
@@ -16,7 +17,11 @@ template(name="form_details")
                 .col-md-4
                   +questions_add form=form questions=questionsCollection
               .col-md-8
-                +questions form=form survey=survey questions=questionsCollection
+                +questions(
+                  form=form
+                  survey=survey
+                  surveyState=surveyState
+                  questions=questionsCollection)
     else
      +loading
 

--- a/app/packages/questions/views/question_details.jade
+++ b/app/packages/questions/views/question_details.jade
@@ -3,6 +3,7 @@ template(name="question_details")
     +form_header(
       path='forms'
       survey=survey
+      surveyState=surveyState
       classNames='small'
       form=form
       showEdit=true)
@@ -17,6 +18,7 @@ template(name="question_details")
             formId=../formId
             question=question
             choices=choices
+            surveyState=surveyState
             type=type)
       else
         +loading

--- a/app/packages/surveys/controllers/edit_survey_modal.coffee
+++ b/app/packages/surveys/controllers/edit_survey_modal.coffee
@@ -2,10 +2,9 @@
 validator = require 'bootstrap-validator'
 
 Template.edit_survey_modal.onCreated ->
-  @surveys = @data.surveys
   @saving = new ReactiveVar false
   @survey = @data.survey
-  @surveyAttrs = @data.surveyAttrs
+  @surveyDetails = @data.surveyDetails
   @surveyObjectId = new ReactiveVar @survey?.id
   @fetched = new ReactiveVar false
 
@@ -18,8 +17,8 @@ Template.edit_survey_modal.onRendered ->
 Template.edit_survey_modal.helpers
   saving: ->
     Template.instance().saving.get()
-  survey: ->
-    Template.instance().surveyAttrs?.get()
+  surveyDetails: ->
+    Template.instance().surveyDetails?.get()
 
 afterSurveySave = (isNewSurvey, survey, instance, event) ->
   instance.saving.set false
@@ -32,7 +31,9 @@ afterSurveySave = (isNewSurvey, survey, instance, event) ->
     , 300)
   else
     # Update the existing details
-    instance.surveyAttrs.set survey.toJSON()
+    instance.surveyDetails.set
+      title: survey.get 'title'
+      description: survey.get 'description'
 
 Template.edit_survey_modal.events
   'submit form': (event, instance) ->

--- a/app/packages/surveys/controllers/survey.coffee
+++ b/app/packages/surveys/controllers/survey.coffee
@@ -8,7 +8,10 @@ Template.survey.onCreated ->
   query.get(surveyId)
     .then (survey) ->
       instance.survey = survey
-      instance.surveyAttrs = new ReactiveVar instance.survey.toJSON()
+      instance.surveyDetails = new ReactiveVar
+        title: survey.get 'title'
+        description: survey.get 'description'
+      instance.surveyState = new ReactiveVar survey.get('active')
       instance.fetched.set true
     .fail (error) ->
       toastr error.message
@@ -17,13 +20,16 @@ Template.survey.helpers
   survey: ->
     Template.instance().survey
   title: ->
-    Template.instance().surveyAttrs.get().title
-  active: ->
-    Template.instance().surveyAttrs.get().active
-  surveyAttrs: ->
-    Template.instance().surveyAttrs
+    Template.instance().surveyDetails.get().title
+  desciption: ->
+    Template.instance().surveyDetails.get().description
+  surveyDetails: ->
+    Template.instance().surveyDetails
+  surveyState: ->
+    Template.instance().surveyState
   data: ->
     instance = Template.instance()
     survey: instance.survey
     formId: instance.data.formId
     questionId: instance.data.questionId
+    surveyState: instance.surveyState

--- a/app/packages/surveys/controllers/survey_details.coffee
+++ b/app/packages/surveys/controllers/survey_details.coffee
@@ -1,6 +1,7 @@
 Template.survey_details.onCreated ->
   @survey = @data.survey
-  @surveyAttrs = @data.surveyAttrs
+  @surveyDetails = @data.surveyDetails
+  @surveyState = @data.surveyState
   @forms = new Meteor.Collection null
   @fetched = new ReactiveVar false
   @active = new ReactiveVar @survey.get 'active'
@@ -29,7 +30,10 @@ Template.survey_details.onCreated ->
 
 Template.survey_details.helpers
   survey: ->
-    Template.instance().surveyAttrs.get()
+    Template.instance().survey
+
+  description: ->
+    Template.instance().surveyDetails.get().description
 
   forms: ->
     Template.instance().forms?.find {}, sort: {order: 1}
@@ -58,6 +62,6 @@ Template.survey_details.events
         survey.setUserACL(activeState.get())
       .then ->
         instance.activating.set false
+        instance.surveyState.set activeState.get()
         state = (if activeState.get() then "activated" else "deactivated")
         toastr.success("You have " + state + " your survey.")
-        FlowRouter.go("/surveys/#{instance.survey.id}")

--- a/app/packages/surveys/views/edit_survey_modal.jade
+++ b/app/packages/surveys/views/edit_survey_modal.jade
@@ -15,7 +15,7 @@ template(name="edit_survey_modal")
             input.form-control(
               type='string'
               name='title'
-              value=survey.title
+              value=surveyDetails.title
               maxlength='128'
               minlength='3'
               required)
@@ -24,7 +24,7 @@ template(name="edit_survey_modal")
           .form-group
             label
               span Description
-            textarea.form-control(type='string' name='description') {{#if survey }}#{survey.description}{{/if}}
+            textarea.form-control(type='string' name='description')=surveyDetails.description
 
         .modal-footer
           button.btn.btn-default(data-dismiss='modal' aria-hidden='true' type='button') Cancel

--- a/app/packages/surveys/views/survey.jade
+++ b/app/packages/surveys/views/survey.jade
@@ -27,10 +27,13 @@ template(name="survey")
                   a.survey-admin--view-link(href="{{pathFor 'survey_results' id=survey.id}}" data-page='results') Results
 
       if isActiveRoute 'survey_details'
-        +survey_details survey=survey surveyAttrs=surveyAttrs
+        +survey_details(
+          survey=survey
+          surveyDetails=surveyDetails
+          surveyState=surveyState)
 
       else if isActiveRoute 'forms'
-        +forms survey=survey
+        +forms survey=survey surveyState=surveyState
 
       else if isActiveRoute regex='form_edit|form_new'
         +form_edit data
@@ -39,17 +42,20 @@ template(name="survey")
         +form_details data
 
       else if isActiveRoute 'question_details'
-          +question_details data
+        +question_details data
 
       else if isActiveRoute 'survey_users'
-        +survey_users survey=survey
+        +survey_users survey=survey surveyState=surveyState
 
       else if isActiveRoute 'survey_results'
-        +survey_results survey=survey
+        +survey_results survey=survey surveyState=surveyState
 
       else if isActiveRoute 'survey_user_edit'
-        +survey_user_edit survey=survey
+        +survey_user_edit survey=survey surveyState=surveyState
 
-    +edit_survey_modal survey=survey surveyAttrs=surveyAttrs
+    +edit_survey_modal(
+      survey=survey
+      surveyDetails=surveyDetails
+      surveyState=surveyState)
   else
     +loading

--- a/app/packages/surveys/views/survey_details.jade
+++ b/app/packages/surveys/views/survey_details.jade
@@ -6,7 +6,7 @@ template(name="survey_details")
     .container-fluid-padded
       .survey--details
         if fetched
-          p.description= survey.description
+          p.description=description
           button.btn.btn-primary.activate(disabled="{{#if activating}} true {{/if}}")
             if activating
               span.fa.fa-spinner.fa-pulse


### PR DESCRIPTION
Fixes: https://www.pivotaltracker.com/story/show/122083291

Creates/updates 2 reactive variables. One stores the survey title and description and the other stores the survey active state. These are handed down to pertinent templates as needed

The global helper [here](https://github.com/ecohealthalliance/mobile-survey/blob/2ad7709ef11258212c25a6deca82f4d2032f64f8/app/packages/_helpers/template_helpers.coffee#L4-L6) uses the `surveyState` reactiveVar.