### PR TITLE
Remove call to setACL method when survey is activated

### DIFF
--- a/app/packages/surveys/imports/activation.coffee
+++ b/app/packages/surveys/imports/activation.coffee
@@ -8,11 +8,9 @@ activate = (instance) ->
   activeState.set not activeState.get()
   props =
     active: activeState.get()
+  instance.activating.set true
   instance.data.survey.save(props)
     .then (survey) ->
-      instance.activating.set true
-      survey.setUserACL(activeState.get())
-    .then ->
       instance.activating.set false
       instance.data.surveyState.set activeState.get()
       state = (if activeState.get() then "activated" else "deactivated")


### PR DESCRIPTION
Fixes an issue related to me being a little premature in fully implementing the invited users stuff (giving permissions to users on activation). 

PT Bug: https://www.pivotaltracker.com/story/show/126308365