### PR TITLE
Show results of 3 most recent short and long answer submissions

### DIFF
--- a/app/packages/results/controllers/form_results_detail.coffee
+++ b/app/packages/results/controllers/form_results_detail.coffee
@@ -1,15 +1,20 @@
 Template.form_results_detail.helpers
   template: ->
     type = @type
-    if type is 'date'
+    if type in ['longAnswer', 'shortAnswer']
+      type = 'text_answer'
+    else if type is 'date'
       type = 'datetime'
     "#{type}_results"
 
   templateData: ->
     question = @
-    answers = []
+    questionId = @objectId
+    answers = new Meteor.Collection null
     Template.instance().data.submissions.forEach (submission) ->
-      answers.push submission.answers[question.objectId]
+      answers.insert
+        content: submission.answers[questionId]
+        createdAt: submission.createdAt
 
     question: question
     answers: answers

--- a/app/packages/results/controllers/types/basic_results_info.coffee
+++ b/app/packages/results/controllers/types/basic_results_info.coffee
@@ -14,3 +14,7 @@ Template.type_icon.helpers
         'calendar'
       when 'number'
         'hashtag'
+      when 'shortAnswer'
+        'minus'
+      when 'longAnswer'
+        'align-left'

--- a/app/packages/results/controllers/types/datetime_results.coffee
+++ b/app/packages/results/controllers/types/datetime_results.coffee
@@ -1,18 +1,19 @@
 { moment } = require 'meteor/momentjs:moment'
 
 Template.datetime_results.onCreated ->
-  dates = _.pluck @data.answers, 'iso'
-  dateTimeStamps = _.map dates, (date) ->
-    new Date(date).valueOf()
-  @dates = _.map dates, (date) ->
-    moment date
+  dateTimeStamps = []
+  momentDates = []
+  @data.answers.find().forEach (answer) ->
+    date = answer.content.iso
+    dateTimeStamps.push date
+    momentDates.push moment date
 
   @summaryDetails = new Meteor.Collection null
 
   total = 0
   for dateTimeStamp in dateTimeStamps
     total += dateTimeStamp
-  average = new Date Math.round(total / dates.length)
+  average = new Date Math.round(total / dateTimeStamps.length)
   average = moment(average)
 
   @summaryDetails.insert
@@ -20,13 +21,13 @@ Template.datetime_results.onCreated ->
     date: average.format 'MMMM D, YYYY'
     time: average.format 'h:mm:ss a'
 
-  latest = moment.min @dates
+  latest = moment.min momentDates
   @summaryDetails.insert
     detailName: 'Latest'
     date: latest.format 'MMMM D, YYYY'
     time: latest.format 'h:mm:ss a'
 
-  earliest = moment.max @dates
+  earliest = moment.max momentDates
   @summaryDetails.insert
     detailName: 'Earliest'
     date: earliest.format 'MMMM D, YYYY'

--- a/app/packages/results/controllers/types/number_results.coffee
+++ b/app/packages/results/controllers/types/number_results.coffee
@@ -2,7 +2,7 @@ highchartOptions = require '../../imports/highcharts_options'
 
 Template.number_results.onRendered ->
   props = @data.question.properties
-  answers = @data.answers
+  answers = _.pluck @data.answers.find().fetch(), 'content'
 
   {averageChartOptions, lowestChartOptions, highestChartOptions} =
     highchartOptions.buildGaugeChartOptions props, answers

--- a/app/packages/results/controllers/types/scale_results.coffee
+++ b/app/packages/results/controllers/types/scale_results.coffee
@@ -2,7 +2,7 @@ highchartOptions = require '../../imports/highcharts_options'
 
 Template.scale_results.onRendered ->
   props = @data.question.properties
-  answers = @data.answers
+  answers = _.pluck @data.answers.find().fetch(), 'content'
 
   {averageChartOptions, lowestChartOptions, highestChartOptions} =
     highchartOptions.buildGaugeChartOptions props, answers

--- a/app/packages/results/controllers/types/text_answer_results.coffee
+++ b/app/packages/results/controllers/types/text_answer_results.coffee
@@ -1,0 +1,9 @@
+moment = require 'moment'
+
+Template.text_answer_results.helpers
+  recentAnswers: ->
+    Template.instance().data.answers.find {},
+      sort: createdAt: -1
+      limit: 3
+  createdAt: ->
+    moment(@createdAt).format 'MMMM D, YYYY'

--- a/app/packages/results/package.js
+++ b/app/packages/results/package.js
@@ -25,11 +25,13 @@ Package.onUse(function(api) {
     'views/types/datetime_results.jade',
     'views/types/number_results.jade',
     'views/types/scale_results.jade',
+    'views/types/text_answer_results.jade',
     'controllers/survey_results.coffee',
     'controllers/types/basic_results_info.coffee',
     'controllers/types/datetime_results.coffee',
     'controllers/types/number_results.coffee',
     'controllers/types/scale_results.coffee',
+    'controllers/types/text_answer_results.coffee',
     'controllers/form_results_detail.coffee'
   ], 'client');
 });

--- a/app/packages/results/styles/question_results.import.styl
+++ b/app/packages/results/styles/question_results.import.styl
@@ -59,9 +59,12 @@
 .question-results--summary
   display flex
   flex 3
-  padding 35px
-  align-items center
-  text-align center
+  padding 25px
+  &.centered
+    align-items center
+    text-align center
+  &.full-width
+    flex-direction column
 
 .summary-items
   flex 1
@@ -75,3 +78,9 @@
     margin 0
     h5
       margin-bottom 0
+  &.full-width
+    max-width 70%
+  .date
+    display block
+    font-style italic
+    color $d-gray

--- a/app/packages/results/views/types/datetime_results.jade
+++ b/app/packages/results/views/types/datetime_results.jade
@@ -1,6 +1,5 @@
 template(name="datetime_results")
-  +basic_results_info type=type particpation=particpation
-  .question-results--summary
+  .question-results--summary.centered
     .summary-items
       span.statistic.major=averageDate.date
       if datetime

--- a/app/packages/results/views/types/text_answer_results.jade
+++ b/app/packages/results/views/types/text_answer_results.jade
@@ -1,0 +1,6 @@
+template(name="text_answer_results")
+  .question-results--summary.full-width
+    each recentAnswers
+      .summary-item.full-width
+        p=content
+        span.date=createdAt


### PR DESCRIPTION
Implements both short and long answer submissions.
Notable change: I changed `answers` to a Meteor collection and added createdAt. I figured it would be easier to sort and query for the 3 most recent if its a collection.

PT Stories: 
https://www.pivotaltracker.com/story/show/123151771
https://www.pivotaltracker.com/story/show/123152151