### PR TITLE
Select first user and show results

### DIFF
--- a/app/packages/participants/controllers/participants.coffee
+++ b/app/packages/participants/controllers/participants.coffee
@@ -5,7 +5,6 @@ Template.participants.onCreated ->
 
 Template.participants.onRendered ->
   @survey = @data.survey
-  @fetched.set false
   @users = new Meteor.Collection null
   instance = @
   _participants = null
@@ -26,7 +25,7 @@ Template.participants.onRendered ->
         _participant = participant.toJSON()
         instance.participants.insert _participant
     .then ->
-      instance.participants.find().forEach (participant) ->
+      instance.participants.find().forEach (participant, i, participants) ->
         _participant = new Parse.User()
         _participant.id = participant.objectId
         query = new Parse.Query 'Submission'
@@ -36,11 +35,12 @@ Template.participants.onRendered ->
           .then (submission) ->
             if submission
               instance.participants.update {_id: participant._id}, {$set: {hasSubmitted: true}}
+            if i == participants.count() - 1
+              instance.fetched.set true
           .fail (err) ->
             console.log err
     .fail (err) ->
       toastr.error err.message
-    .always ->
       instance.fetched.set true
 
 Template.participants.helpers

--- a/app/packages/results/imports/highcharts_helpers.coffee
+++ b/app/packages/results/imports/highcharts_helpers.coffee
@@ -105,7 +105,6 @@ buildGaugeChartOptions = (props, answers) ->
 showGaugeChart = (instance, elementNamePrefix) ->
   props = instance.data.question.properties
   answers = pluckAnswers instance.data.answers
-  console.log props, answers
 
   {averageChartOptions, lowestChartOptions, highestChartOptions} =
     buildGaugeChartOptions props, answers

--- a/app/packages/results/imports/results_helpers.coffee
+++ b/app/packages/results/imports/results_helpers.coffee
@@ -3,7 +3,6 @@
   @param [Object] answers, answers containing content and createdAt
 ###
 pluckAnswers = (answers) ->
-  console.log answers
   _.pluck answers.find().fetch(), 'content'
 
 


### PR DESCRIPTION
Refactor participant collections
Sort participant lists

@Broham We may want to think about doing this for forms as well. The load time of a results of a survey with a bunch of forms will be pretty long. We may want to show only the first form on page load. 

PT Story: https://www.pivotaltracker.com/story/show/126645397