### PR TITLE
Add min/max-widths to results views

### DIFF
--- a/app/packages/_components/list_flank/list_flank.styl
+++ b/app/packages/_components/list_flank/list_flank.styl
@@ -41,6 +41,7 @@ $flank-padding = 22%
 
 
 .list-flank
+  min-width 300px
   h5
     padding-top .75em
     padding-bottom .75em

--- a/app/packages/_styles/index.styl
+++ b/app/packages/_styles/index.styl
@@ -1,3 +1,4 @@
+
 @import '{gq:base-styles}/variables'
 @import '{gq:base-styles}/globals'
 @import '{gq:base-styles}/utilities'

--- a/app/packages/participants/styles/results.import.styl
+++ b/app/packages/participants/styles/results.import.styl
@@ -17,7 +17,7 @@
 
 .results--details
   flex 4
-  padding 15px
+  overflow-x scroll
   .user
     padding-top .75em
     padding-bottom .75em

--- a/app/packages/results/styles/index.styl
+++ b/app/packages/results/styles/index.styl
@@ -10,6 +10,8 @@
 
 .form-results
   margin-bottom 65px
+  padding 15px
+  min-width 800px
 
 .form-results--header
   background white

--- a/app/packages/results/styles/question_results.import.styl
+++ b/app/packages/results/styles/question_results.import.styl
@@ -3,7 +3,7 @@
   font-size 3em
   font-weight 800
   color $primary
-  line-height 1
+  line-height 1.5
   &.minor
     color $d-gray
     font-size 1.5em
@@ -15,6 +15,16 @@
     font-size 1.25em
     font-weight 400
     color $d-gray
+
+@media(max-width:1200px)
+  .statistic
+    font-size 2em
+    &.minor
+      font-size 1.25em
+    &.major
+      font-size 1.5em
+    &.minimal
+      font-size 1em
 
 .question-results
   margin-bottom 20px
@@ -46,7 +56,8 @@
 
 .question-results--basic-info
   flex 1
-  min-width 300px
+  min-width 150px
+  max-width 200px
   border-right 2px solid $border-primary-l
 
 .basic-info--item
@@ -69,6 +80,7 @@
 .summary-items
   flex 1
   border-right 1px solid $border-primary-l
+  padding 0 1em
   &:last-of-type
     border 0
   &.left


### PR DESCRIPTION
This starts making the form-results section a little more friendly for smaller screens. Still work to be done.

PT Bug: https://www.pivotaltracker.com/story/show/126866999