### PR TITLE
Move formatQuestionType helper to correct template

### DIFF
--- a/app/packages/results/controllers/types/basic_results_info.coffee
+++ b/app/packages/results/controllers/types/basic_results_info.coffee
@@ -4,8 +4,6 @@ Template.basic_results_info.helpers
   hasRange: ->
     @type in ['number', 'scale']
 
-  formatQuestionType: -> formatQuestionType(@type)
-
 Template.type_icon.helpers
   icon: ->
     type = Template.instance().data.type
@@ -26,3 +24,5 @@ Template.type_icon.helpers
         'sliders'
       when 'shortAnswer'
         'minus'
+
+  formatQuestionType: -> formatQuestionType(@type)


### PR DESCRIPTION
Noticed the question type disappeared after merging recent PRs. This moves a helper to the correct template and fixes the issue.