### PR TITLE
Reduce size of long range numbers

### DIFF
--- a/app/packages/results/controllers/types/basic_results_info.coffee
+++ b/app/packages/results/controllers/types/basic_results_info.coffee
@@ -1,8 +1,31 @@
 { formatQuestionType } = require 'meteor/gq:helpers'
 
+checkNumberLength = (instance, number) ->
+  numDigits = number.toString().length
+  if numDigits > 4
+    instance.longContent.set true
+
+  if numDigits > 8
+    number.toExponential 3
+  else
+    number
+
+Template.basic_results_info.onCreated ->
+  @longContent = new ReactiveVar false
+
 Template.basic_results_info.helpers
   hasRange: ->
     @type in ['number', 'scale']
+
+  min: ->
+    checkNumberLength Template.instance(), @props.min
+
+  max: ->
+    console.log @props.max
+    checkNumberLength Template.instance(), @props.max
+
+  longContent: ->
+    Template.instance().longContent.get()
 
 Template.type_icon.helpers
   icon: ->

--- a/app/packages/results/styles/question_results.import.styl
+++ b/app/packages/results/styles/question_results.import.styl
@@ -64,8 +64,26 @@
   padding 20px 10px
   text-align center
   border-bottom 1px solid $border-primary-l
+  .through
+    font-weight 400
+    &::before
+      display inline-block
+      content '-'
   &:last-of-type
     border 0
+  &.long-content
+    .statistic
+      font-size 2em
+      span
+        display block
+        line-height 1
+        margin-bottom 5px
+      .through
+        margin-bottom 10px
+        &::before
+          content 'to'
+          font-size .75em
+          color $d-gray
 
 .question-results--summary
   display flex

--- a/app/packages/results/views/types/basic_results_info.jade
+++ b/app/packages/results/views/types/basic_results_info.jade
@@ -3,8 +3,11 @@ template(name="basic_results_info")
     .basic-info--item
       +type_icon type=type
     if hasRange
-      .basic-info--item
-        span.statistic #{props.min} - #{props.max}
+      .basic-info--item(class="{{#if longContent}} long-content {{/if}}")
+        span.statistic
+          span=min
+          span.through
+          span=max
         h5 Range
     .basic-info--item
       span.statistic #{participation.percentage}%


### PR DESCRIPTION
Fixes an issue that occurred when range numbers had a huge number of digits.
Now when digit length exceeds 4, the range is shown like this:
![screen shot 2016-08-03 at 11 59 10 am](https://cloud.githubusercontent.com/assets/4105343/17372426/d323a2ea-5971-11e6-8398-5896bcb9b842.png)

PT Bug: https://www.pivotaltracker.com/story/show/126889919
