### PR TITLE
increase order of questions and forms via Parse's built-in operation

### DIFF
--- a/app/packages/_api/form.coffee
+++ b/app/packages/_api/form.coffee
@@ -32,14 +32,6 @@ Form = Parse.Object.extend 'Form',
         else
           questions
 
-  getLastQuestionOrder: ->
-    query = @relation('questions').query()
-    query.descending 'order'
-    query.select 'order'
-    query.first()
-      .then (lastQuestion) ->
-        lastQuestion?.get('order')
-
   getQuestion: (questionId) ->
     query = @relation('questions').query()
     query.equalTo 'objectId', questionId
@@ -71,11 +63,9 @@ Form = Parse.Object.extend 'Form',
 
   addQuestion: (props) ->
     form = @
-    @getLastQuestionOrder()
-      .then (lastQuestionOrder) ->
-        question = new Question()
-        props.deleted = false
-        question.create(props, lastQuestionOrder, form)
+    question = new Question()
+    props.deleted = false
+    question.create(props, form)
       .then (question) ->
         question
 

--- a/app/packages/_api/question.coffee
+++ b/app/packages/_api/question.coffee
@@ -1,9 +1,12 @@
 { setAdminACL } = require 'meteor/gq:helpers'
 
 Question = Parse.Object.extend 'Question',
-  create: (props, lastQuestionOrder, form) ->
+  create: (props, form) ->
     question = @
-    props.order = ++lastQuestionOrder or 1
+    props.order = {
+      __op: "Increment"
+      amount: 1
+    }
     props.createdBy = Parse.User.current()
     setAdminACL(question)
       .then ->
@@ -20,7 +23,7 @@ Question = Parse.Object.extend 'Question',
       .then =>
         @
 
-  delete: (deleted = true) ->
+  delete: (deleted=true) ->
     @set 'deleted', deleted
     @save()
 

--- a/app/packages/_api/survey.coffee
+++ b/app/packages/_api/survey.coffee
@@ -42,21 +42,16 @@ Survey = Parse.Object.extend 'Survey',
       .then (form) ->
         form
 
-  getLastFormOrder: ->
-    query = @relation('forms').query()
-    query.descending 'order'
-    query.select 'order'
-    query.first().then (lastForm) ->
-      lastForm?.get('order')
-
   buildForm: (props) ->
-    @getLastFormOrder().then (lastFormOrder) ->
-      order = ++lastFormOrder or 1
-      title: props.title
-      createdBy: Parse.User.current()
-      order: order
-      trigger: props.trigger
-      deleted: false
+    order = {
+      __op: "Increment"
+      amount: 1
+    }
+    title: props.title
+    createdBy: Parse.User.current()
+    order: order
+    trigger: props.trigger
+    deleted: false
 
   addForm: (props) ->
     survey = @

--- a/app/packages/questions/controllers/questions.coffee
+++ b/app/packages/questions/controllers/questions.coffee
@@ -39,7 +39,7 @@ Template.questions.events
   'click .delete-question': (event, instance) ->
     query = new Parse.Query Question
     query.get(@objectId)
-      .then (question) =>
+      .then (question) ->
         question.delete()
       .then () =>
         instance.questions.remove @_id


### PR DESCRIPTION
This PR gets rid of the previous implementation and uses Parse's __op "Increment" function on the server which allows us to avoid duplicate order values among questions in the same form and for forms in the same survey.
